### PR TITLE
Port to reqwest, clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,12 @@ documentation = "https://docs.rs/openmensa-rs"
 [dependencies]
 chrono = "0.4.9"
 failure = "0.1.6"
-serde = { version = "^1.0", features = ["derive"] }
-http = "0.1.19"
-url = "2.1.0"
-serde_urlencoded = "0.6.1"
 getset = "0.0.9"
+reqwest = "0.10"
+serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0.41"
-surf = "1.0.3"
+serde_urlencoded = "0.6.1"
+url = "2.1"
 
 [dev-dependencies]
 tokio = { version="^0.2", features= ["macros"] }

--- a/examples/canteens.rs
+++ b/examples/canteens.rs
@@ -4,7 +4,7 @@ use openmensa_rs::{request::CanteenRequest, CoordinatePair};
 async fn main() {
     println!("Canteens known: ");
     let list = CanteenRequest::new()
-        .with_near_coordinates(CoordinatePair::new(52.139618827301902, 11.6475999355316))
+        .with_near_coordinates(CoordinatePair::new(52.139_618, 11.647_599))
         .build()
         .await;
     println!("{:#?}", list);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 use std::convert::From;
-use surf::Exception;
 
 /// Possible Errors are summed up as `RequestError` each variant describes a possible error that could occur at different stages.
 #[derive(Debug, Fail)]
@@ -20,10 +19,10 @@ pub enum RequestError {
     ParserError { error: url::ParseError },
 }
 
-impl From<Exception> for RequestError {
-    fn from(_error: Exception) -> Self {
+impl From<reqwest::Error> for RequestError {
+    fn from(_error: reqwest::Error) -> Self {
         Self::ConnectionError {
-            reason: "Request failed to go through, this error happened in `surf`".to_string(),
+            reason: "Request failed to go through, this error happened in `reqwest`".to_string(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,11 @@
 //! A simple example would be requesting a list of all available canteens in the api.
 //!
 //! ```rust
+//! # tokio::runtime::Runtime::new().unwrap().block_on(async {
 //! use openmensa_rs::request::CanteenRequest;
 //!
-//! #[tokio::main]
-//! async fn main() {
 //! let list = CanteenRequest::new().build().await.unwrap();
-//! }
+//! # })
 //! ```
 //!
 //! For a closer look on what you can specify in these requests go over to the documentation of these structs to see all available options and a more in-depth example.

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -5,38 +5,36 @@
 //!
 //! Each of the three request can carry additional information you may want to filter by e.g.
 //! ```rust
+//! # tokio::runtime::Runtime::new().unwrap().block_on(async {
 //! use openmensa_rs::request::CanteenRequest;
 //! use openmensa_rs::CoordinatePair;
 //!
-//! #[tokio::main]
-//! async fn main() {
-//!     let near_canteens = CanteenRequest::new()
-//!         .with_near_coordinates(
-//!             CoordinatePair::new(
-//!                 52.1396188273019,
-//!                 11.6475999355316,
-//!             )
+//! let near_canteens = CanteenRequest::new()
+//!     .with_near_coordinates(
+//!         CoordinatePair::new(
+//!             52.1396188273019,
+//!             11.6475999355316,
 //!         )
-//!         .build()
-//!         .await
-//!         .unwrap();
-//! }
+//!     )
+//!     .build()
+//!     .await
+//!     .unwrap();
+//! # })
 //! ```
 //!
 //! specifiy a location for canteens (for more option have a look at the structs themselves).
 //!
 //! Or the range from which opening days may be returned:
 //! ```rust
+//! # tokio::runtime::Runtime::new().unwrap().block_on(async {
 //! use openmensa_rs::request::DayRequest;
 //!
-//! #[tokio::main]
-//! async fn main() {
-//!     let near_canteens = DayRequest::new(1)
-//!         .with_start_date(chrono::Utc::today())
-//!         .build()
-//!         .await
-//!         .unwrap();
-//! }
+//! let near_canteens = DayRequest::new(1)
+//!     .with_start_date(chrono::Utc::today())
+//!     .build()
+//!     .await
+//!     .unwrap();
+//! # })
 //! ```
 
 mod canteen_request;


### PR DESCRIPTION
This PR contains a port from `surf` to the recently released `reqwest` 0.10. Unlike `surf` it is 100% Rust (does not depend on `libcurl`), is based on `hyper` and works well with Tokio runtime.

Also included are a bunch of doc fixes to resolve clippy complaints.